### PR TITLE
Add support for annotation attribute description rendering

### DIFF
--- a/src/main/java/org/ballerinalang/docgen/docs/html/HtmlDocumentWriter.java
+++ b/src/main/java/org/ballerinalang/docgen/docs/html/HtmlDocumentWriter.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -153,6 +154,8 @@ public class HtmlDocumentWriter implements DocumentWriter {
      * @param absoluteFilePath absolute file path of the output html file
      */
     private void writeHtmlDocument(Object object, String templateName, String absoluteFilePath) {
+        // TODO: fix this properly
+        HashSet<String> processedReturnAnnots = new HashSet<>();
         PrintWriter writer = null;
         try {
             Handlebars handlebars =
@@ -237,7 +240,10 @@ public class HtmlDocumentWriter implements DocumentWriter {
                             if (annotation.getAttributes().size() > 1) {
                                 continue;
                             }
-                            if (isNameEqual(annotationName, annotation)) {
+                            // Temporary work around to get the return params mapped to the return param annotation
+                            if (isNameEqual(annotationName, annotation)
+                                    && !processedReturnAnnots.contains(annotation.getPosition().toString())) {
+                                processedReturnAnnots.add(annotation.getPosition().toString());
                                 return annotation.getAttributes().get(0).getValue().getValue().toString();
                             }
                         }
@@ -270,6 +276,20 @@ public class HtmlDocumentWriter implements DocumentWriter {
                             }
                             if (isNameEqual(annotationName, annotation)) {
                                 return annotation.getAttributes().get(0).getValue().getValue().toString();
+                            }
+                        }
+                        return "";
+                    })
+                    .registerHelper("annotFieldAnnotation", (Helper<BLangAnnotAttribute>) (annot, options) -> {
+                        List<BLangAnnotationAttachment> annotationAttachments = getAnnotations(dataHolder);
+
+                        for (BLangAnnotationAttachment annotation : annotationAttachments) {
+                            if ("Field".equals(annotation.getAnnotationName().getValue())) {
+                                String value = annotation.getAttributes().get(0).getValue().getValue().toString();
+                                if (value.startsWith(annot.getName().getValue())) {
+                                    String[] valueParts = value.split(":");
+                                    return valueParts.length == 2 ? valueParts[1] : valueParts[0];
+                                }
                             }
                         }
                         return "";

--- a/src/main/resources/docerina-templates/html/package.hbs
+++ b/src/main/resources/docerina-templates/html/package.hbs
@@ -189,6 +189,7 @@
                             <h3 id="{{name}}">annotation {{name}}</h3>
                             <p>{{oneValueAnnotation "description"}}</p>
 
+                            {{#if attributes}}
                             <p>
                                 <b>Attributes:</b>
                                 <table>
@@ -197,11 +198,12 @@
                                     </tr>
                                     {{#each attributes}}
                                     <tr>
-                                        <td>{{name}}</td><td><a href="{{#bindLink typeNode}}{{/bindLink}}"{{typeTitle typeNode}}>{{annotationTypeText typeNode}}</a></td><td>{{attributeAnnotation this "attributeDef"}}</td>
+                                        <td>{{name}}</td><td><a href="{{#bindLink typeNode}}{{/bindLink}}"{{typeTitle typeNode}}>{{annotationTypeText typeNode}}</a></td><td>{{annotFieldAnnotation}}</td>
                                     </tr>
                                     {{/each}}
                                 </table>
                             </p>
+                            {{/if}}
                         </div>
                         {{/each}}
                         <p></p>


### PR DESCRIPTION
This PR adds support for rendering descriptions of annotation attributes and fixes the issue with return param description being the same for all return params in multi return scenarios.

Fixes #132, #127 